### PR TITLE
Remove strict elixir and OTP versions from project and CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,30 +2,38 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - elixir: "1.16.x"
+            otp: "26.x"
+          - elixir: 1.15.x
+            otp: "25.x"
+          - elixir: 1.14.x
+            otp: "25.x"
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Elixir
-      uses: erlef/setup-beam@v1
-      with:
-        version-type: strict
-        version-file: .tool-versions
-    - name: Restore dependencies cache
-      uses: actions/cache@v2
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Run tests
-      run: mix test
+      - uses: actions/checkout@v4
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run tests
+        run: mix test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 25.1.2
-elixir 1.14.3

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule JsonSchema.MixProject do
   use Mix.Project
 
   @version "0.5.0"
-  @elixir_version "1.14.3"
+  @elixir_version "~> 1.14"
 
   def project do
     [


### PR DESCRIPTION
Fixes #143

In addition to fixing the strict version in `mix.exs` I've also updated the CI action to use a matrix to test on multiple Elixir/OTP combinations, and removed the .tool-versions file.