### PR TITLE
Support draft-04

### DIFF
--- a/lib/parser/root_parser.ex
+++ b/lib/parser/root_parser.ex
@@ -136,6 +136,7 @@ defmodule JsonSchema.Parser.RootParser do
   end
 
   @supported_versions [
+    "http://json-schema.org/draft-04/schema#",
     "http://json-schema.org/draft-07/schema#"
   ]
 


### PR DESCRIPTION
I've tested this against a schema targeting draft-04 and it works fine. What would be the down-sides of just adding it to the list of supported versions?